### PR TITLE
Add fast_methods benchmark for Colab

### DIFF
--- a/fast_methods/README.md
+++ b/fast_methods/README.md
@@ -1,0 +1,11 @@
+# Fast Object Detection Methods
+
+This folder contains an experiment to benchmark different approaches for detecting anomalous objects in video data on a GPU (e.g. Google Colab with an A100).
+
+The following detection strategies are briefly considered:
+
+1. **Deep Learning Detectors** – modern single-stage models such as YOLOv8 or YOLOX provide real-time object detection (hundreds of frames per second on an A100). They require labelled training data or pre-trained weights.
+2. **Background Subtraction** – frame differencing and running averages are extremely fast but only handle static cameras and predictable backgrounds.
+3. **Mahalanobis Distance** – modelling the distribution of video clips with covariance estimators (e.g. the robust TMCD algorithm). Outliers can be spotted by thresholding the squared Mahalanobis distance.
+
+The supplied notebook demonstrates how to time the Mahalanobis-based approach and serves as a template for comparing against deep-learning baselines.

--- a/fast_methods/mahalanobis_benchmark.ipynb
+++ b/fast_methods/mahalanobis_benchmark.ipynb
@@ -1,0 +1,77 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Mahalanobis Benchmark\n",
+    "Basic example of computing Mahalanobis distances for video clips with the TMCD algorithm.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import os, zipfile, time, torch\n",
+    "from code.tmcd_fuctions_gpu import tmcd, _invSqrt, computeTensorMD\n",
+    "\n",
+    "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')\n",
+    "zip_path = '/content/tensor_dataset_sea.zip'  # upload zip here\n",
+    "assert os.path.exists(zip_path), 'tensor_dataset_sea.zip not found'\n",
+    "with zipfile.ZipFile(zip_path, 'r') as zf:\n",
+    "    zf.extractall('/content')\n",
+    "dataset = torch.load('/content/tensor_dataset_bigShip.pt', map_location='cpu')\n",
+    "X_full = (dataset.to(torch.float32) / 255.).to(device).contiguous()\n",
+    "\n",
+    "# optional: drop every 4th frame\n",
+    "idx = torch.arange(X_full.size(-1), device=X_full.device)\n",
+    "mask = (idx % 4) != 0\n",
+    "X_full = X_full[..., mask].contiguous()\n",
+    "\n",
+    "n, p1, p2, p3 = X_full.shape\n",
+    "print(f'Loaded: {n} clips  ({p1}\u00d7{p2}\u00d7{p3})')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "start = time.perf_counter()\n",
+    "tmcd_res = tmcd(X_full, alpha=0.6, nSubsets=100, nBest=10,\n",
+    "                 maxIterCshort=2, maxIterFFshort=2,\n",
+    "                 maxIterCfull=20, maxIterFFfull=50,\n",
+    "                 tolC=1e-4, tolFF=1e-3, beta=0.9999)\n",
+    "if torch.cuda.is_available():\n",
+    "    torch.cuda.synchronize()\n",
+    "elapsed = time.perf_counter() - start\n",
+    "print(f'TMCD finished in {elapsed:.1f}s')\n",
+    "print('Good clips:', tmcd_res['finalGood'].numel(), '/', n)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "invSqrt1 = _invSqrt(tmcd_res['Sigma1'])\n",
+    "invSqrt2 = _invSqrt(tmcd_res['Sigma2'])\n",
+    "invSqrt3 = _invSqrt(tmcd_res['Sigma3'])\n",
+    "TMDsq_all = computeTensorMD(X_full, invSqrt1, invSqrt2, invSqrt3)\n",
+    "top_md2, top_idx = torch.topk(TMDsq_all.cpu(), k=5, largest=True)\n",
+    "print('Top clips:', list(zip(top_idx.tolist(), top_md2.tolist())))\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Summary
- add `fast_methods` folder with a short README describing fast approaches
- provide `mahalanobis_benchmark.ipynb` notebook to run TMCD on Colab

## Testing
- `git status --short`